### PR TITLE
JOHNZON-35

### DIFF
--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/Mapper.java
@@ -107,7 +107,7 @@ public class Mapper {
         } else if (type == long.class || type == Long.class) {
             return generator.write(Long.class.cast(value).longValue());
         } else if (isInt(type)) {
-            return generator.write(Integer.class.cast(value).intValue());
+            return generator.write(Number.class.cast(value).intValue());
         } else if (isFloat(type)) {
             final double doubleValue = Number.class.cast(value).doubleValue();
             if (Double.isNaN(doubleValue)) {

--- a/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/MapperTest.java
+++ b/johnzon-mapper/src/test/java/org/apache/johnzon/mapper/MapperTest.java
@@ -137,6 +137,21 @@ public class MapperTest {
 
         assertEquals(instance, instance2);
     }
+    
+    
+   @Test
+   public void writeShortArray() {
+        StringWriter writer = new StringWriter();
+        new MapperBuilder().build().writeArray(new Short[]{(short)1,(short)2,(short)3},writer);
+        assertEquals("[1,2,3]", writer.toString());
+   }
+   
+   @Test
+   public void writeByteArray() {
+       StringWriter writer = new StringWriter();
+       new MapperBuilder().build().writeArray(new Byte[]{(byte)1,(byte)2,(byte)3},writer);
+       assertEquals("[1,2,3]", writer.toString());
+   }
 
     static class Bool {
         private boolean bool;


### PR DESCRIPTION
Mapper fails on short and byte array
Changed the use of Integer.class.cast to Number.class.cast