### PR TITLE
[JOHNZON-44] - The manifest neglects OSGi Import/Export information

### DIFF
--- a/johnzon-core/pom.xml
+++ b/johnzon-core/pom.xml
@@ -31,4 +31,5 @@
   <properties>
     <staging.directory>${project.parent.reporting.outputDirectory}</staging.directory>
   </properties>
+  <packaging>bundle</packaging>
 </project>

--- a/johnzon-jaxrs/pom.xml
+++ b/johnzon-jaxrs/pom.xml
@@ -66,4 +66,5 @@
     <staging.directory>${project.parent.reporting.outputDirectory}</staging.directory>
     <cxf.version>3.0.0</cxf.version>
   </properties>
+  <packaging>bundle</packaging>
 </project>

--- a/johnzon-mapper/pom.xml
+++ b/johnzon-mapper/pom.xml
@@ -39,4 +39,5 @@
   <properties>
     <staging.directory>${project.parent.reporting.outputDirectory}</staging.directory>
   </properties>
+  <packaging>bundle</packaging>
 </project>

--- a/johnzon-websocket/pom.xml
+++ b/johnzon-websocket/pom.xml
@@ -94,4 +94,5 @@
       </plugin>
     </plugins>
   </build>
+  <packaging>bundle</packaging>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <johnzon.site.url>https://svn.apache.org/repos/asf/incubator/johnzon/site/publish/</johnzon.site.url>
     <pubsub.url>scm:svn:${johnzon.site.url}</pubsub.url>
     <staging.directory>${project.build.directory}/site</staging.directory>
+    <felix.plugin.version>2.5.4-SNAPSHOT</felix.plugin.version>
+    <bnd.version.policy>[$(version;==;$(@)),$(version;+;$(@)))</bnd.version.policy>
   </properties>
 
   <modules>
@@ -319,6 +321,20 @@
          <configuration>
          </configuration>
        </plugin>
+       <plugin>
+         <groupId>org.apache.felix</groupId>
+         <artifactId>maven-bundle-plugin</artifactId>
+         <version>${felix.plugin.version}</version>
+         <inherited>true</inherited>
+         <extensions>true</extensions>
+         <configuration>
+             <instructions>
+                 <_removeheaders>Private-Package,Include-Resource,Embed-Dependency,Created-By,Bnd-LastModified,Built-By,Tool</_removeheaders>
+                 <_versionpolicy>${bnd.version.policy}</_versionpolicy>
+                 <Bundle-DocURL>http://johnzon.incubator.apache.org/</Bundle-DocURL>
+             </instructions>
+         </configuration>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This takes care of the generation of the OSGi Package Import/Export information