### PR TITLE
fix(JOHNZON-426): BigInteger/BigDecimal string adapter flags swapped

### DIFF
--- a/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
+++ b/johnzon-jsonb/src/main/java/org/apache/johnzon/jsonb/JohnzonBuilder.java
@@ -233,6 +233,16 @@ public class JohnzonBuilder implements JsonbBuilder {
                         Integer.parseInt(it.toString()))
                 .ifPresent(builder::setSnippetMaxLength);
 
+        or(config.getProperty("johnzon.use-biginteger-stringadapter"),
+                () -> Optional.ofNullable(System.getProperty("johnzon.use-biginteger-stringadapter")))
+                .map(Object::toString).map(Boolean::parseBoolean)
+                .ifPresent(builder::setUseBigIntegerStringAdapter);
+
+        or(config.getProperty("johnzon.use-bigdecimal-stringadapter"),
+                () -> Optional.ofNullable(System.getProperty("johnzon.use-bigdecimal-stringadapter")))
+                .map(Object::toString).map(Boolean::parseBoolean)
+                .ifPresent(builder::setUseBigDecimalStringAdapter);
+
         // user adapters
         final Types types = new Types();
 
@@ -453,6 +463,10 @@ public class JohnzonBuilder implements JsonbBuilder {
         config.getProperty("org.apache.johnzon.supports-comments").ifPresent(b -> map.put("org.apache.johnzon.supports-comments", b));
         config.getProperty("org.apache.johnzon.buffer-strategy").ifPresent(b -> map.put("org.apache.johnzon.buffer-strategy", b));
         return map;
+    }
+
+    private static <T> Optional<T> or(Optional<T> first, Supplier<Optional<T>> second) {
+        return first.isPresent() ? first : second.get();
     }
 
     private static abstract class Lazy<T> implements Supplier<T> {

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbBigDecimalTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbBigDecimalTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.johnzon.jsonb;
+
+import org.apache.johnzon.jsonb.test.JsonbRule;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.json.bind.annotation.JsonbProperty;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class JsonbBigDecimalTest {
+    @Rule
+    public final JsonbRule rule = new JsonbRule()
+            .withProperty("johnzon.use-biginteger-stringadapter", "false")
+            .withProperty("johnzon.use-bigdecimal-stringadapter", "false")
+            ;
+
+    private static class BigNumberWrapper {
+        @JsonbProperty("bd")
+        private BigDecimal bd;
+
+        @JsonbProperty("bi")
+        private BigInteger bi;
+
+        public BigDecimal getBd() {
+            return bd;
+        }
+
+        public void setBd(BigDecimal bd) {
+            this.bd = bd;
+        }
+
+        public BigInteger getBi() {
+            return bi;
+        }
+
+        public void setBi(BigInteger bi) {
+            this.bi = bi;
+        }
+    }
+
+    @Test
+    public void jsonValue() {
+        final BigNumberWrapper bnw = new BigNumberWrapper();
+        bnw.setBd(new BigDecimal("0.000000733915"));
+        bnw.setBi(new BigInteger("9223372036854775808"));
+
+        final String json = rule.toJson(bnw);
+        Assert.assertEquals("{\"bd\":7.33915E-7,\"bi\":9223372036854775808}", json);
+    }
+}

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbTypesTest.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/JsonbTypesTest.java
@@ -21,6 +21,8 @@ package org.apache.johnzon.jsonb;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
@@ -63,7 +65,8 @@ public class JsonbTypesTest {
         final LocalDate localDate = LocalDate.of(2015, 1, 1);
         final LocalTime localTime = LocalTime.of(1, 2, 3);
         final LocalDateTime localDateTime = LocalDateTime.of(2015, 1, 1, 1, 1);
-        final String expected = "{\"calendar\":\"2015-01-01T01:01:00Z[UTC]\",\"date\":\"2015-01-01T01:01:00Z[UTC]\"," +
+        final String expected = "{\"bigDecimal\":\"1.5\",\"bigInteger\":\"1\"," +
+                "\"calendar\":\"2015-01-01T01:01:00Z[UTC]\",\"date\":\"2015-01-01T01:01:00Z[UTC]\"," +
                 "\"duration\":\"PT30S\",\"gregorianCalendar\":\"2015-01-01T01:01:00Z[UTC]\"," +
                 "\"instant\":\"2015-01-01T00:00:00Z\",\"localDate\":\"2015-01-01\"," +
                 "\"localDateTime\":\"2015-01-01T01:01\",\"localTime\":\"01:02:03\"," +
@@ -104,6 +107,23 @@ public class JsonbTypesTest {
     }
 
     @Test
+    public void testReadAndWriteBigIntDecimalAsNumbers() throws Exception {
+        final String expected = "{\"bigDecimal\":1.5,\"bigInteger\":1}";
+        final Jsonb jsonb = newJsonb(
+                new JsonbConfig()
+                        .setProperty("johnzon.use-biginteger-stringadapter", false)
+                        .setProperty("johnzon.use-bigdecimal-stringadapter", false));
+
+        final Types types = jsonb.fromJson(new StringReader(expected), Types.class);
+        assertEquals(BigInteger.valueOf(1), types.bigInteger);
+        assertEquals(BigDecimal.valueOf(1.5), types.bigDecimal);
+
+        assertEquals(expected, jsonb.toJson(types));
+
+        jsonb.close();
+    }
+
+    @Test
     public void readAndWriteWithDateFormats() throws Exception {
         readAndWriteWithDateFormat(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"), "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         readAndWriteWithDateFormat(DateTimeFormatter.ofPattern("yyyyMMdd+HHmmssZ"), "yyyyMMdd+HHmmssZ");
@@ -134,7 +154,7 @@ public class JsonbTypesTest {
     }
     
     private static Jsonb newJsonb() {
-        return newJsonb(null);
+        return newJsonb((String) null);
     }
     
     private static Jsonb newJsonb(String dateFormat) {
@@ -142,12 +162,17 @@ public class JsonbTypesTest {
         if (!StringUtils.isEmpty(dateFormat)){
             jsonbConfig.withDateFormat(dateFormat, Locale.getDefault());
         }
-        return JsonbProvider.provider().create().withConfig(jsonbConfig.setProperty("johnzon.attributeOrder", new Comparator<String>() {
+
+        return newJsonb(jsonbConfig.setProperty("johnzon.attributeOrder", new Comparator<String>() {
             @Override
             public int compare(final String o1, final String o2) {
                 return o1.compareTo(o2);
             }
-        })).build();
+        }));
+    }
+
+    private static Jsonb newJsonb(JsonbConfig jsonbConfig) {
+        return JsonbProvider.provider().create().withConfig(jsonbConfig).build();
     }
 
     public static class Types {
@@ -172,6 +197,8 @@ public class JsonbTypesTest {
         private LocalDate localDate;
         private OffsetDateTime offsetDateTime;
         private OffsetTime offsetTime;
+        private BigInteger bigInteger;
+        private BigDecimal bigDecimal;
 
         public LocalTime getLocalTime() {
             return localTime;
@@ -341,6 +368,22 @@ public class JsonbTypesTest {
             this.offsetTime = offsetTime;
         }
 
+        public BigDecimal getBigDecimal() {
+            return bigDecimal;
+        }
+
+        public void setBigDecimal(BigDecimal bigDecimal) {
+            this.bigDecimal = bigDecimal;
+        }
+
+        public BigInteger getBigInteger() {
+            return bigInteger;
+        }
+
+        public void setBigInteger(BigInteger bigInteger) {
+            this.bigInteger = bigInteger;
+        }
+
         @Override
         public boolean equals(final Object o) {
             if (this == o) {
@@ -369,7 +412,9 @@ public class JsonbTypesTest {
                 Objects.equals(localDateTime, types.localDateTime) &&
                 Objects.equals(localDate, types.localDate) &&
                 Objects.equals(offsetDateTime, types.offsetDateTime) &&
-                Objects.equals(offsetTime, types.offsetTime);
+                Objects.equals(offsetTime, types.offsetTime) &&
+                Objects.equals(bigInteger, types.bigInteger) &&
+                Objects.equals(bigDecimal, types.bigDecimal);
         }
 
         @Override
@@ -377,7 +422,7 @@ public class JsonbTypesTest {
             return Objects.hash(
                 url, uri, optionalString, optionalInt, optionalLong, optionalDouble, date,
                 calendar, gregorianCalendar, timeZone, zoneId, zoneOffset, simpleTimeZone, instant, duration,
-                period, localDateTime, localDate, offsetDateTime, offsetTime);
+                period, localDateTime, localDate, offsetDateTime, offsetTime, bigInteger, bigDecimal);
         }
     }
 

--- a/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/test/JsonbRule.java
+++ b/johnzon-jsonb/src/test/java/org/apache/johnzon/jsonb/test/JsonbRule.java
@@ -62,6 +62,11 @@ public class JsonbRule implements TestRule, Jsonb, JsonbExtension {
         return this;
     }
 
+    public JsonbRule withProperty(final String propertyName, final Object value) {
+        config.setProperty(propertyName, value);
+        return this;
+    }
+
     @Override
     public Statement apply(final Statement statement, final Description description) {
         return new Statement() {

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/MapperBuilder.java
@@ -269,6 +269,16 @@ public class MapperBuilder {
         return this;
     }
 
+    public MapperBuilder setUseBigIntegerStringAdapter(final boolean convertBigIntegerToString) {
+        adapters.setUseBigIntegerStringAdapter(convertBigIntegerToString);
+        return this;
+    }
+
+    public MapperBuilder setUseBigDecimalStringAdapter(final boolean convertBigDecimalToString) {
+        adapters.setUseBigDecimalStringAdapter(convertBigDecimalToString);
+        return this;
+    }
+
     public MapperBuilder setAdaptersDateTimeFormatterString(final String dateTimeFormatter) {
         adapters.setDateTimeFormatter(DateTimeFormatter.ofPattern(dateTimeFormatter));
         return this;
@@ -526,16 +536,6 @@ public class MapperBuilder {
 
     public MapperBuilder setUseJsRange(boolean value) {
         this.useJsRange = value;
-        return this;
-    }
-
-    public MapperBuilder setUseBigIntegerStringAdapter(final boolean convertBigIntegerToString) {
-        adapters.setUseBigIntegerStringAdapter(convertBigIntegerToString);
-        return this;
-    }
-
-    public MapperBuilder setUseBigDecimalStringAdapter(final boolean convertBigDecimalToString) {
-        adapters.setUseBigDecimalStringAdapter(convertBigDecimalToString);
         return this;
     }
 

--- a/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/map/LazyConverterMap.java
+++ b/johnzon-mapper/src/main/java/org/apache/johnzon/mapper/map/LazyConverterMap.java
@@ -86,8 +86,8 @@ public class LazyConverterMap extends ConcurrentHashMap<AdapterKey, Adapter<?, ?
     private boolean useShortISO8601Format = true;
     private DateTimeFormatter dateTimeFormatter;
     // I-JSON (RFC 7493 Section 2.2): BigX exceed IEEE 754 double, string is safer by default.
-    // Set -Djohnzon.use-ijson-big-number-stringadapter.disabled=true for strict JSON-B 3.0 / TCK compliance.
-    private static final boolean IJSON_BIG_NUMBER_DEFAULT = !Boolean.getBoolean("johnzon.use-ijson-big-number-stringadapter.disabled");
+    // Set -Djohnzon.use-big-number-stringadapter=false for strict JSON-B 3.0 / TCK compliance.
+    private static final boolean IJSON_BIG_NUMBER_DEFAULT = !Boolean.getBoolean("johnzon.use-big-number-stringadapter.disabled");
     private boolean useBigIntegerStringAdapter = IJSON_BIG_NUMBER_DEFAULT;
     private boolean useBigDecimalStringAdapter = IJSON_BIG_NUMBER_DEFAULT;
 
@@ -99,11 +99,11 @@ public class LazyConverterMap extends ConcurrentHashMap<AdapterKey, Adapter<?, ?
         this.dateTimeFormatter = dateTimeFormatter;
     }
 
-    public void setUseBigDecimalStringAdapter(final boolean useBigDecimalStringAdapter) {
+    public void setUseBigDecimalStringAdapter(boolean useBigDecimalStringAdapter) {
         this.useBigDecimalStringAdapter = useBigDecimalStringAdapter;
     }
 
-    public void setUseBigIntegerStringAdapter(final boolean useBigIntegerStringAdapter) {
+    public void setUseBigIntegerStringAdapter(boolean useBigIntegerStringAdapter) {
         this.useBigIntegerStringAdapter = useBigIntegerStringAdapter;
     }
 
@@ -139,13 +139,13 @@ public class LazyConverterMap extends ConcurrentHashMap<AdapterKey, Adapter<?, ?
 
     public Set<AdapterKey> adapterKeys() {
         return Stream.concat(
-                super.keySet().stream()
-                        .filter(it -> super.get(it) != NO_ADAPTER),
-                Stream.of(Date.class, URI.class, URL.class, Class.class, String.class, BigDecimal.class, BigInteger.class,
-                        Locale.class, Period.class, Duration.class, Calendar.class, GregorianCalendar.class, TimeZone.class,
-                        ZoneId.class, ZoneOffset.class, SimpleTimeZone.class, Instant.class, LocalDateTime.class, LocalDate.class,
-                        ZonedDateTime.class, OffsetDateTime.class, OffsetTime.class)
-                        .map(it -> new AdapterKey(it, String.class, true)))
+                        super.keySet().stream()
+                                .filter(it -> super.get(it) != NO_ADAPTER),
+                        Stream.of(Date.class, URI.class, URL.class, Class.class, String.class, BigDecimal.class, BigInteger.class,
+                                        Locale.class, Period.class, Duration.class, Calendar.class, GregorianCalendar.class, TimeZone.class,
+                                        ZoneId.class, ZoneOffset.class, SimpleTimeZone.class, Instant.class, LocalDateTime.class, LocalDate.class,
+                                        ZonedDateTime.class, OffsetDateTime.class, OffsetTime.class)
+                                .map(it -> new AdapterKey(it, String.class, true)))
                 .collect(toSet());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@
                   <property name="ignorePattern" value="@version|@see" />
                 </module>
                 <module name="MethodLength">
-                  <property name="max" value="250" />
+                  <property name="max" value="260" />
                 </module>
                 <module name="ParameterNumber">
                   <property name="max" value="11" />


### PR DESCRIPTION
Replacing #136. This incorporates this change: https://github.com/apache/johnzon/commit/dc6b20557259755b2448fe600673357770a2869a, and should be more consistent with master.