### PR TITLE
fix: Add required ASF policy links to site footer

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -89,9 +89,16 @@
     
     <footer>
         <![CDATA[
-        <div class="row span16"><div>Apache Johnzon, Apache, the Apache feather logo, and the Apache Johnzon project logos are trademarks of The Apache Software Foundation.
+        <div class="row span16"><div>Copyright &copy; 2014-2026 The Apache Software Foundation.<br/>
+        Apache Johnzon, Apache, the Apache logo, and the Apache Johnzon project logos are trademarks of The Apache Software Foundation.
         All other marks mentioned may be trademarks or registered trademarks of their respective owners.</div>
-        <a href="${project.url}/privacy-policy.html">Privacy Policy</a>
+        <a href="https://www.apache.org/">Foundation</a> |
+        <a href="https://www.apache.org/events/current-event.html">Events</a> |
+        <a href="https://www.apache.org/licenses/">License</a> |
+        <a href="https://www.apache.org/security/">Security</a> |
+        <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+        <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+        <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
         </div>
         ]]>
     </footer>


### PR DESCRIPTION
The Johnzon website is failing 6 of 9 ASF website policy checks (https://whimsy.apache.org/site/):

- Foundation link (in nav menu but not detected by scanner)
- Events (missing)
- License (missing)
- Security (existing link is broken - points to #)
- Copyright (missing)
- Privacy (pointed to project-level page)

This adds all required ASF policy links to the footer section of site.xml, adds a copyright line, and updates the trademark text ("Apache feather logo" → "Apache logo").

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/